### PR TITLE
Don't try to autoload files without a '.nn' extension

### DIFF
--- a/src/sources/network.c
+++ b/src/sources/network.c
@@ -121,7 +121,7 @@ int nn_create(Network *nn, size_t layers, const size_t layerSizes[], int activat
     {
         if (activationIds[i] > ACTIVATION_COUNT || activationIds[i] < 0)
         {
-            fprintf(stderr, "nn_create(): Activation id %d doesn't exist\n", nn->activationIds[i]);
+            fprintf(stderr, "nn_create(): Activation id %d doesn't exist\n", activationIds[i]);
             goto create_error;
         }
         nn->activationIds[i] = activationIds[i];

--- a/src/sources/uci.c
+++ b/src/sources/uci.c
@@ -30,7 +30,7 @@
 #include "types.h"
 #include "uci.h"
 
-#define UCI_VERSION "v0.4.0"
+#define UCI_VERSION "v0.4.1"
 
 const cmdlink_t commands[] =
 {
@@ -509,6 +509,14 @@ int find_network(const char *path)
     while ((entry = readdir(dir)) != NULL)
     {
         extern Network NN;
+        char *lastDot = strrchr(entry->d_name, '.');
+
+        if (lastDot == NULL)
+            continue ;
+
+        // Check the file extension before trying to autoload it
+        if (strcmp(lastDot, ".nn"))
+            continue ;
 
         if (!nn_load(&NN, entry->d_name))
         {


### PR DESCRIPTION
Also fix compilation errors while logging invalid activation IDs.